### PR TITLE
Upgrade aiohttp to 3.9.5 to fix issues with Python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: MIT
 
-aiohttp==3.9.1
+aiohttp==3.9.5
 Pillow==10.1.0


### PR DESCRIPTION
This library (`api.mcsrvstat.py`) doesn't work on Python 3.12 because it fails to build the wheels for `aiohttp` version 3.9.1.

This issue is already fixed in `aiohttp`, however, this project is using an outdated version of that library. This pull request upgrades `aiohttp`, which (should) fix the issue and make the library work on Python 3.12 again.